### PR TITLE
zsh fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd cms-hlt-parser
 voms-proxy-init -voms cms
 
 # always run the setup (which installs some software _once_)
-source setup
+source setup.sh
 ```
 
 

--- a/hltp/files/env_bril.sh
+++ b/hltp/files/env_bril.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+hltp_pip_install() {
+        PYTHONUSERBASE="$HLTP_SOFTWARE" pip install -I --user --no-cache-dir "$@"
+    }
+
 action() {
     local bril_version="$( law config hltp_config.bril_version )"
     export PATH="$PATH:/afs/cern.ch/cms/lumi/brilconda-$bril_version/bin"


### PR DESCRIPTION
- typo
- `hltp_pip_install` is not available from `setup.sh` sourcing, but since the only other place it's used is `hltp/files/env_bril.sh` I just added it there as well.